### PR TITLE
ECHOACCESS-158: Add cursor to related collections

### DIFF
--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -481,6 +481,8 @@ interface Relationship {
 type RelatedCollectionsList {
   "The number of related collections available."
   count: Int
+  "Cursor that points to the/a specific position in a list of requested records."
+  cursor: String
   "The list of related collections."
   items: [RelatedCollection]
 }


### PR DESCRIPTION
### Description

In this PR, we have added a new field `cursor` to the `RelatedCollectionsList` type in the GraphQL schema definition file.

Changes:
- Added a new field `cursor` of type `String` to the `RelatedCollectionsList` GraphQL type.

These changes enable the `RelatedCollectionsList` type to include a cursor that points to a specific position in a list of requested records, enhancing the navigation within related collections.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `cursor` field to the `RelatedCollectionsList` type in the GraphQL schema to indicate a specific position in a list of requested records.

### Why are these changes being made?

This change is being made to support pagination in the related collections feature, allowing clients to efficiently navigate through large sets of related collections by using a cursor. This approach enhances the user experience by enabling more precise data retrieval and reducing the load on the server.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->